### PR TITLE
Optimize loading sketch file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 capnp = { version = "0.9.4", optional = true}
 clap = "~2.32.0"
 failure = "0.1.2"
+memmap = "0.7.0"
 murmurhash3 = "~0.0.5"
 ndarray = "0.12"
 needletail = "0.2.2"


### PR DESCRIPTION
Tested with 316MB refseq_sketches_21_1000.sk. On the current master branch, this file takes 5.5 seconds to load on my machine. This PR implements three improvements that bring that down to 1.1 seconds, which is 5x faster.