### PR TITLE
 Make raw_distance function commutative 

### DIFF
--- a/src/distance.rs
+++ b/src/distance.rs
@@ -172,17 +172,8 @@ mod tests {
         assert_eq!(com, 0);
         assert_eq!(total, 2);
 
-        let (cont, jac, com, total) = raw_distance(&kc(&[]), &kc(&[]), 0.);
-        assert_eq!(cont, 0.);
-        assert_eq!(jac, 1.);
-        assert_eq!(com, 0);
-        assert_eq!(total, 0);
-
-        let (cont, jac, com, total) = raw_distance(&kc(&[]), &kc(&[5]), 0.);
-        assert_eq!(cont, 0.);
-        assert_eq!(jac, 1.);
-        assert_eq!(com, 0);
-        assert_eq!(total, 0);
+        assert_eq!((0., 1., 0, 0), raw_distance(&kc(&[]), &kc(&[]), 0.));
+        assert_eq!((0., 1., 0, 0), raw_distance(&kc(&[]), &kc(&[5]), 0.));
     }
 
     #[test]

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -149,12 +149,6 @@ mod tests {
         assert_eq!(com, 0);
         assert_eq!(total, 2);
 
-        let (cont, jac, com, total) = raw_distance(&kc(&[2, 0]), &kc(&[1]), 0.);
-        assert_eq!(cont, 0.);
-        assert_eq!(jac, 0.);
-        assert_eq!(com, 0);
-        assert_eq!(total, 1);
-
         let (cont, jac, com, total) = raw_distance(&kc(&[]), &kc(&[]), 0.);
         assert_eq!(cont, 0.);
         assert_eq!(jac, 1.);


### PR DESCRIPTION
I added a property test that `raw_distance(sequence1, sequence2, 0.) == raw_distance(sequence2, sequence1, 0.)`, and it failed at first. Then I refactored the raw_distance function to have broadly similar behavior (still passes all tests), but use more idiomatic Rust, and be shorter and simpler. In doing so, I managed to make it pass the commutativity test. This doesn't exactly fix a problem (see below) so I'll understand if it is not merged.

### On what case did the old raw_distance function fail?
`raw_distance(&[2, 0], &[1], 0.) == (0.0, NaN, 0, 0)` and `raw_distance(&[1], &[2, 0], 0.) == (0.0, NaN, 0, 0)`. Since `Nan != Nan` this technically fails the commutativity test, although the practical use of that result is questionable. Also I think `raw_distance` is supposed to take only sorted slices as inputs (but couldn't find any documentation saying so), so the commutativity proptest might be completely invalid.
