### PR TITLE
Fix bug with reverse complement not being normalized.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "finch"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bincode",
  "capnp",

--- a/lib/src/sketch_schemes/mash.rs
+++ b/lib/src/sketch_schemes/mash.rs
@@ -67,10 +67,10 @@ impl MashSketcher {
 
 impl SketchScheme for MashSketcher {
     fn process(&mut self, seq: &SequenceRecord) {
-        self.total_bases += seq.sequence().len() as u64;
-        let rc = seq.reverse_complement();
-        for (_, kmer, is_rev_complement) in
-            seq.normalize(false).canonical_kmers(self.kmer_length, &rc)
+        let norm_seq = seq.normalize(false);
+        self.total_bases += norm_seq.sequence().len() as u64;
+        let rc = norm_seq.reverse_complement();
+        for (_, kmer, is_rev_complement) in norm_seq.canonical_kmers(self.kmer_length, &rc)
         {
             let rc_count = u8::from(is_rev_complement);
             self.push(kmer, rc_count);

--- a/lib/src/sketch_schemes/scaled.rs
+++ b/lib/src/sketch_schemes/scaled.rs
@@ -65,10 +65,10 @@ impl ScaledSketcher {
 
 impl SketchScheme for ScaledSketcher {
     fn process(&mut self, seq: &SequenceRecord) {
-        self.total_bases += seq.sequence().len() as u64;
-        let rc = seq.reverse_complement();
-        for (_, kmer, is_rev_complement) in
-            seq.normalize(false).canonical_kmers(self.kmer_length, &rc)
+        let norm_seq = seq.normalize(false);
+        self.total_bases += norm_seq.sequence().len() as u64;
+        let rc = norm_seq.reverse_complement();
+        for (_, kmer, is_rev_complement) in norm_seq.canonical_kmers(self.kmer_length, &rc)
         {
             let rc_count = u8::from(is_rev_complement);
             self.push(kmer, rc_count);


### PR DESCRIPTION
Fixes bug with reverse complement of sequence not being normalized during identification of canonical kmers. This impacts both fixed and scaled sketches, and results in incorrect containment and Jaccard values.