### PR TITLE
Fix for Dockerfile smell DL3025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ COPY --from=builder \
     /home/rust/finch/target/x86_64-unknown-linux-musl/release/finch* \
     /usr/local/bin/
 
-CMD /bin/bash
+CMD ["/bin/bash"]


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3025](https://github.com/hadolint/hadolint/wiki/DL3025) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3025 occurs if the JSON notation is not used for the arguments of CMD and ENTRYPOINT instructions.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, the command arguments are refactored in the JSON notation format.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance
